### PR TITLE
Warn about api docs build failure

### DIFF
--- a/sphinx_api_sidebar/sphinx_api_sidebar.py
+++ b/sphinx_api_sidebar/sphinx_api_sidebar.py
@@ -8,7 +8,7 @@ from sphinx.util import logging
 logger = logging.getLogger(__name__)
 
 TEMPLATE_CONTENT = """{% if api_docs %}
-    <h3>{{ _('API Documentation') }}</h3>
+    <h4>{{ _('API Documentation') }}</h4>
     <ul style="list-style-type: none;">
     {%- for item in api_docs %}
         <li style="margin-bottom: 10px;"><a href="{{ pathto('_static/api-docs/{}'.format(item), 1) }}">{{ item }}</a></li>

--- a/sphinx_api_sidebar/sphinx_api_sidebar.py
+++ b/sphinx_api_sidebar/sphinx_api_sidebar.py
@@ -59,7 +59,7 @@ def generate_api_sidebar(app, config):
 
         result = subprocess.run([f"{command}"], text=True, shell=True, capture_output=True)
         if result.returncode != 0:
-            logger.warning(f"Command '{command}' failed with return code {result.returncode}: {result.stderr}")
+            logger.warning(f"Command '{command}' failed with return code {result.returncode}: {result.stderr}", color="yellow")
             continue
 
         # iterate through the list of dictionaries and copy the generated API docs to the static/api-docs directory
@@ -73,7 +73,8 @@ def generate_api_sidebar(app, config):
 
                 api_docs.append(api_doc_name)
             except Exception as e:
-                logger.warning(f"An error occurred while picking up API docs from {output_path}: {e}")
+                ## warn the user that the API docs could not be picked up in yellow
+                logger.warning(f"Could not copy API docs from {output_path}: {e}", color="yellow")
                 continue
 
     # update html_context with api_docs


### PR DESCRIPTION
## Summary

This PR updates the plugin that when the API docs build fail, it will provide a warning rather than failing the whole sphinx build.

## Testing
pytest
test it locally